### PR TITLE
#6 added throttling for Mac touchpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 npm-debug.log
+.idea

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "Slideshow framework for Vue.js",
   "main": "src/main.js",
-  "url" : "https://github.com/zulko/eagle.js",
+  "url": "https://github.com/zulko/eagle.js",
   "directories": {
     "example": "example"
   },
@@ -16,9 +16,10 @@
   "author": "Zulko",
   "license": "ISC",
   "dependencies": {
-    "vue": "2.1.10",
+    "animate.css": "3.5.2",
     "highlight.js": "9.9.0",
-    "animate.css": "3.5.2"
+    "lodash": "^4.17.4",
+    "vue": "2.1.10"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",
@@ -61,7 +62,6 @@
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.16.1",
     "webpack-merge": "^2.6.1",
-
     "pug": "2.0.0-beta11",
     "sass-loader": "5.0.0",
     "node-sass": "4.5.0"

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -1,4 +1,5 @@
 <script>
+import _ from 'lodash'
 export default {
   props: {
     firstSlide: {default: 1},
@@ -53,7 +54,7 @@ export default {
       }
       if (this.mouseNavigation) {
         window.addEventListener('click', this.click)
-        window.addEventListener('wheel', this.wheel)
+        window.addEventListener('wheel', _.throttle(this.wheel, 1000))
       }
       if (this.embedded) {
         this.$el.className += ' embedded-slideshow'
@@ -151,6 +152,8 @@ export default {
       }
     },
     wheel: function (evt) {
+      console.log("Wheel", evt)
+
       if (this.mouseNavigation && this.currentSlide.mouseNavigation) {
         evt.preventDefault()
         if ((evt.wheelDeltaY > 0) || (evt.deltaY > 0)) {

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -54,6 +54,7 @@ export default {
       }
       if (this.mouseNavigation) {
         window.addEventListener('click', this.click)
+        // TODO you need to play with this time 1000 – it's good for Mac but i'm not sure about other devices
         window.addEventListener('wheel', _.throttle(this.wheel, 1000))
       }
       if (this.embedded) {
@@ -152,8 +153,6 @@ export default {
       }
     },
     wheel: function (evt) {
-      console.log("Wheel", evt)
-
       if (this.mouseNavigation && this.currentSlide.mouseNavigation) {
         evt.preventDefault()
         if ((evt.wheelDeltaY > 0) || (evt.deltaY > 0)) {


### PR DESCRIPTION
You need to play with throttling time. 1000 – it's good for Mac but i'm not sure about other devices.
If you don't want to have lodash as dependency you can just clone one throttle method from that.
It's just quick fix for #6 :)