### PR TITLE
Allow for custom next and previous slide transitions.

### DIFF
--- a/src/components/Slide.vue
+++ b/src/components/Slide.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-eg-transition(:enter='enter', :leave='leave')
+eg-transition(:enter='enterTransition', :leave='leaveTransition')
   .eg-slide(v-if='active')
     .eg-slide-content
       slot
@@ -10,7 +10,11 @@ export default {
   props: {
     skip: {default: false},
     enter: {default: null},
+    enterPrev: {default: null},
+    enterNext: { default: null},
     leave: {default: null},
+    leavePrev: {default: null},
+    leaveNext: { default: null},
     steps: {default: 1},
     mouseNavigation: {default: true},
     keyboardNavigation: {default: true}
@@ -20,7 +24,26 @@ export default {
       step: 1,
       active: false,
       isSlide: true,
-      slideTimer: 0
+      slideTimer: 0,
+      direction: "next",
+      transitions: {
+        next: {
+          enter: this.enterNext || this.enter,
+          leave: this.leaveNext || this.leave
+        },
+        prev: {
+          enter: this.enterPrev || this.enter,
+          leave: this.leavePrev || this.leave
+        }
+      }
+    }
+  },
+  computed: {
+    enterTransition: function() {
+      return this.transitions[this.direction].enter
+    },
+    leaveTransition: function() {
+      return this.transitions[this.direction].leave
     }
   },
   mounted: function () {

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -86,18 +86,30 @@ export default {
   },
   methods: {
     nextStep: function () {
-      if (this.step === this.currentSlide.steps) {
-        this.nextSlide()
-      } else {
-        this.step++
-      }
+      this.slides.forEach(function (slide) {
+        slide.direction = "next"
+      });
+      var self = this
+      this.$nextTick(function() {
+        if (self.step === self.currentSlide.steps) {
+          self.nextSlide()
+        } else {
+          self.step++
+        }
+      })
     },
     previousStep: function () {
-      if (this.step === 1) {
-        this.previousSlide()
-      } else {
-        this.step--
-      }
+      this.slides.forEach(function (slide) {
+        slide.direction = "prev"
+      });
+      var self = this
+      this.$nextTick(function() {
+        if (self.step === 1) {
+          self.previousSlide()
+        } else {
+          self.step--
+        }
+      })
     },
     nextSlide: function () {
       var nextSlideIndex = this.currentSlideIndex + 1


### PR DESCRIPTION
Using the `enterNext`, `enterPrev`, `leaveNext` and `leavePrev` props, you can specify a different transition for next and previous directions.

If these props are not specified, the value of `enter` or `leave` is used.