### PR TITLE
Keyboard navigation for wireless presenter

### DIFF
--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -182,9 +182,9 @@ export default {
       if (this.keyboardNavigation &&
           (this.currentSlide.keyboardNavigation || evt.ctrlKey || evt.metaKey)) {
         evt.preventDefault()
-        if (evt.key === 'ArrowLeft') {
+        if (evt.key === 'ArrowLeft' || evt.key === 'PageUp') {
           this.previousStep()
-        } else if (evt.key === 'ArrowRight') {
+        } else if (evt.key === 'ArrowRight' || evt.key === 'PageDown') {
           this.nextStep()
         }
       }


### PR DESCRIPTION
Not sure if this belongs to the core repository, but:

If you add `PageUp` and `PageDown` as navigation keys, eagle.js works out of the box with many "Wireless Presenter" devices that emulate a keyboard HID and send those keys for prev/next slide.

(Tested on Ubuntu/Firefox with Logitech R800 Wireless Presenter)