### PR TITLE
Add extension system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Slideshow system built on top of the [Vue.js](https://vuejs.org/)
 - Supports animations, themes, interactive widgets (for web demos)
 - Easy to reuse components, slides and styles across presentations
-- Built-in Presenter Mode (Speaker Notes) and various helpful widgets
+- Lightweight core and various helpful extensions
 - All APIs public, maximum hackability 
 
 ### For a quick tour, see [this slideshow](https://zulko.github.io/eaglejs-demo/#/introducing-eagle):
@@ -75,8 +75,8 @@ yarn add eagle.js
 
 ## Usage
 
-Eagle.js is a vue plugin. You need to `use` eagle.js in your vue app's main file:
-*New in 0.3.0*: `animate.css` is now a peer dependency. User need install their own version.
+Eagle.js is a vue plugin. You need to `use` eagle.js in your vue app's main file.
+**New in 0.3.0**: `animate.css` is now a peer dependency. User need install their own version.
 
 ```javascript
 import Eagle from 'eagle.js'
@@ -88,16 +88,7 @@ import 'animate.css'
 Vue.use(Eagle)
 ```
 
-Using eagle.js's default export would register both core components and all the widgets. Alternatively you can choose only to use core components:
-
-```javascript
-import { Slide, Transition } from 'eagle.js'
-
-Vue.component(Slide.name, Slide)
-Vue.component(Transition.name, Transition)
-```
-
-Then you can selectively use widgets, as you like. See more on [widgets section](https://github.com/Zulko/eagle.js#widgets)
+**New in 0.5.0** Now by default eagle.js doesn't export all plugins but only core components. You have to explicitly use your widgets or plugins from now on. See more on [extensions section](https://github.com/Zulko/eagle.js#extensions)
 
 ### Basic idea
 
@@ -200,19 +191,19 @@ You can configure `slide` with these properties:
 
 Under the hood, `eg-transition` is just vue's `transition` that supports  [animate.css](https://daneden.github.io/animate.css/): you can use animate.css's class name for `enter` and `leave` property and it just works. All eagle.js's transition effects, including `slide`,  happen with this component, and you can use it just like using vue's `transition`.
 
-### Speaker's Notes (Presenter Mode)
+## Extensions
 
-Eagle.js has built-in presenter mode support. By default pressing "P" would toggle presenter mode: you have two windows that share control with each other. Enabling presenter mode gives user two addition `data` for `slideshow`: `parentWindow` and `childWindow`. For example:
+Starting from 0.5.0 we introduction extensions to eagle.js. It includes two categories, namely widgets and plugins:
+1. Widgets are Vue components that can be directly used in a slide.
+2. Plugins are used in slideshow to enhance slide globally.
+Both widgets and plugins have the same interface to use, just like how Vue uses plugins, for example:
 
-```pug
-.eg-slideshow
-  slide
-    p Eagle.is is awesome!
-    p(v-if="parentWindow") I can be a note!
-    p(v-if="childWindow") I can be a note too!
 ```
-
-It might be counter-intuitive that `(v-if="parentWindow")` is actually child window. It's because it means this window has a parent window, thus making itself a child window. But it is really just user's preference to put notes in either window, as two windows are almost functionally identical, except only parent window could close persenter mode.
+// plugin
+Eagle.use(Zoom, {scale: 2})
+// Widget
+Eagle.use(CodeBlock)
+```
 
 ### Widgets
 
@@ -224,13 +215,17 @@ Eagle.js ships several useful widgets that can be used in your `slide`:
 5. `eg-radio-button`
 6. `eg-triggered-message`
 
-You can use widgets as you like:
+Using widgets is really simple
 
 ```javascript
-import { Modal, CodeBlock } from 'eagle.js'
+import Eagle, { Modal, CodeBlock } from 'eagle.js'
 
-Vue.component(Modal.name, Modal)
-Vue.component(CodeBlock.name, CodeBlock)
+Eagle.use(Modal)
+Eagle.use(CodeBlock)
+
+// You can still do this, which eagle does the same under the hood
+// Vue.component(Modal.name, Modal)
+// Vue.component(CodeBlock.name, CodeBlock)
 ```
 Widgets' name follows the same rule: uppercase for importing, `eg` prefixed lowercase connected with dash in HTML.
 See more of their usage in the [demo project](https://github.com/Zulko/eaglejs-demo).
@@ -248,6 +243,42 @@ Options.hljs = hljs
 ```
 
 This way drastically decrease eagle.js's package size and user could manage their own `highlight.js` version.
+
+### Presenter Plugin
+
+You can use presenter plugin to enable presenter mode:
+
+```javascript
+import Eagle, {Presenter} from eagle.js
+
+Eagle.use(Presenter, {
+  presenterModeKey: 'a' // default is p
+})
+```
+
+By default pressing "p" would toggle presenter mode: you have two windows that share control with each other. Enabling presenter mode gives user two addition `data` for `slideshow`: `parentWindow` and `childWindow`. For example:
+
+```pug
+.eg-slideshow
+  slide
+    p Eagle.is is awesome!
+    p(v-if="parentWindow") I can be a note!
+    p(v-if="childWindow") I can be a note too!
+```
+
+It might be counter-intuitive that `(v-if="parentWindow")` is actually child window. It's because it means this window has a parent window, thus making itself a child window. But it is really just user's preference to put notes in either window, as two windows are almost functionally identical, except only parent window could close persenter mode.
+
+### Zoom Plugin
+
+```javascript
+import Eagle, {Zoom} from eagle.js
+
+Eagle.use(Presenter, {
+  scale: 1 // default is 2
+})
+```
+
+Holding command key (or alt key on Windows) + click would zoom in and out.
 
 ## Themes
 

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -6,7 +6,7 @@ var banner = `/*
  * eagle.js v${pkg.version}
  *
  * @license
- * Copyright 2017-2018, Zulko
+ * Copyright 2017-2019, Zulko
  * Released under the ISC License
  */`
 

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -239,7 +239,6 @@ export default {
       Options.plugins.forEach(plugin => {
         plugin[0].init(this, plugin[1])
       })
-      
     },
     unregisterPlugins: function () {
       Options.plugins.forEach(plugin => {

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -136,17 +136,16 @@ export default {
       }
     },
     previousSlide: function () {
-      var self = this
-      var previousSlideIndex = self.currentSlideIndex - 1
+      var previousSlideIndex = this.currentSlideIndex - 1
       while ((previousSlideIndex >= 1) &&
-             (self.slides[previousSlideIndex - 1].skip ||
-              (self.slides[previousSlideIndex - 1].$parent.skip))) {
+             (this.slides[previousSlideIndex - 1].skip ||
+              (this.slides[previousSlideIndex - 1].$parent.skip))) {
         previousSlideIndex--
       }
       if (previousSlideIndex >= 1) {
-        self.currentSlideIndex = previousSlideIndex
-      } else if (!self.embedded) {
-        self.onStartExit()
+        this.currentSlideIndex = previousSlideIndex
+      } else if (!this.embedded) {
+        this.onStartExit()
       }
     },
     handleResize: function () {
@@ -237,18 +236,15 @@ export default {
       }
     },
     registerPlugins: function () {
-      if (Options.plugins) {
-        Options.plugins.forEach(plugin => {
-          plugin[0].init(this, plugin[1])
-        })
-      }
+      Options.plugins.forEach(plugin => {
+        plugin[0].init(this, plugin[1])
+      })
+      
     },
     unregisterPlugins: function () {
-      if (Options.plugins) {
-        Options.plugins.forEach(plugin => {
-          plugin[0].destroy(this)
-        })
-      }
+      Options.plugins.forEach(plugin => {
+        plugin[0].destroy(this)
+      })
     }
   },
   watch: {

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -1,5 +1,6 @@
 <script>
 import throttle from 'lodash.throttle'
+import { Options } from '../main.js'
 
 export default {
   props: {
@@ -10,13 +11,11 @@ export default {
     inserted: {default: false},
     keyboardNavigation: {default: true},
     mouseNavigation: {default: true},
-    presenterModeKey: {default: 'p'},
     onStartExit: {default: () => function () { if (this.$router) this.$router.push('/') }},
     onEndExit: {default: () => function () { if (this.$router) this.$router.push('/') }},
     skip: {default: false},
     backBySlide: {default: false},
-    repeat: {default: false},
-    zoom: {default: true}
+    repeat: {default: false}
   },
   data: function () {
     return {
@@ -26,9 +25,7 @@ export default {
       slideshowTimer: 0,
       slideTimer: 0,
       slides: [],
-      active: true,
-      childWindow: null,
-      parentWindow: null
+      active: true
     }
   },
   computed: {
@@ -50,28 +47,20 @@ export default {
       this.currentSlide = this.slides[this.currentSlideIndex - 1]
       this.currentSlide.step = this.startStep
 
-      if (this.zoom && !this.embedded) {
-        this.handleZoom()
-      }
       // ADD NAVIGATION EVENTS
       if (this.keyboardNavigation) {
-        window.addEventListener('keydown', this.keydown)
+        window.addEventListener('keydown', this.handleKeydown)
       }
       if (this.mouseNavigation) {
         if ('ontouchstart' in window) {
-          window.addEventListener('touchstart', this.click)
+          window.addEventListener('touchstart', this.hanldeClick)
         } else {
-          window.addEventListener('click', this.click)
-          window.addEventListener('wheel', this.wheel)
+          window.addEventListener('click', this.handleClick)
+          window.addEventListener('wheel', this.handleWheel)
         }
       }
       if (this.embedded) {
         this.$el.className += ' embedded-slideshow'
-      }
-      if (window.opener && window.opener.location.href === window.location.href) {
-        this.parentWindow = window.opener
-        this.postMessage('{"method": "getCurrentSlide"}')
-        window.addEventListener('message', this._message)
       }
     }
     window.addEventListener('resize', this.handleResize)
@@ -91,15 +80,16 @@ export default {
       self.slideshowTimer++
       self.slideTimer++
     }, 1000)
+    this.registerPlugins()
     this.afterMounted()
   },
   beforeDestroy: function () {
-    window.removeEventListener('keydown', this.keydown)
-    window.removeEventListener('click', this.click)
-    window.removeEventListener('touchstart', this.click)
-    window.removeEventListener('wheel', this.wheel)
-    this.handleZoom(true)
+    window.removeEventListener('keydown', this.handleKeydown)
+    window.removeEventListener('click', this.handleClick)
+    window.removeEventListener('touchstart', this.handleClick)
+    window.removeEventListener('wheel', this.handleWheel)
     clearInterval(this.timerUpdater)
+    this.unregisterPlugins()
   },
   methods: {
     changeDirection: function (direction) {
@@ -108,7 +98,7 @@ export default {
       })
       this.$root.direction = direction
     },
-    nextStep: function (fromMessage) {
+    nextStep: function () {
       this.changeDirection('next')
       var self = this
       this.$nextTick(function () {
@@ -118,11 +108,8 @@ export default {
           self.step++
         }
       })
-      if (!fromMessage) {
-        this.postMessage('{"method": "nextStep"}')
-      }
     },
-    previousStep: function (fromMessage) {
+    previousStep: function () {
       this.changeDirection('prev')
       var self = this
       this.$nextTick(function () {
@@ -132,9 +119,6 @@ export default {
           self.step--
         }
       })
-      if (!fromMessage) {
-        this.postMessage('{"method": "previousStep"}')
-      }
     },
     nextSlide: function () {
       var nextSlideIndex = this.currentSlideIndex + 1
@@ -180,55 +164,7 @@ export default {
         self.$el.style.fontSize = (0.04 * Math.min(height, width)) + 'px'
       }, 16)()
     },
-    handleZoom: function (remove) {
-      if (remove) {
-        window.removeEventListener('resize', updateCoords)
-        window.removeEventListener('mousedown', magnify)
-        return
-      }
-
-      const SCALE = 2
-      let height = document.documentElement.clientHeight
-      let width = document.documentElement.clientWidth
-      const center = {
-        x: width / 2,
-        y: height / 2
-      }
-      const boundary = {
-        x: center.x / SCALE,
-        y: center.y / SCALE
-      }
-
-      window.addEventListener('resize', updateCoords)
-      window.addEventListener('mousedown', magnify)
-
-      function updateCoords () {
-        height = document.documentElement.clientHeight
-        width = document.documentElement.clientWidth
-        center.x = width / 2
-        center.y = height / 2
-        boundary.x = center.x / SCALE
-        boundary.y = center.y / SCALE
-      }
-
-      function magnify (event) {
-        if (!event.altKey) return
-        if (document.body.style.transform) {
-          document.body.style.transform = ''
-          document.body.style.overflow = 'auto'
-        } else {
-          document.body.style.height = height + 'px'
-          document.body.style.overflow = 'hidden'
-          document.body.style.transition = '0.5s'
-          let translateX = center.x - event.clientX
-          let translateY = center.y - event.clientY
-          translateX = translateX < boundary.x ? translateX > -boundary.x ? translateX : -boundary.x : boundary.x
-          translateY = translateY < boundary.y ? translateY > -boundary.y ? translateY : -boundary.y : boundary.y
-          document.body.style.transform = `scale(${SCALE}) translate(${translateX}px, ${translateY}px)`
-        }
-      }
-    },
-    click: function (evt) {
+    handleClick: function (evt) {
       if (this.mouseNavigation && this.currentSlide.mouseNavigation && !evt.altKey) {
         var clientX = evt.clientX != null ? evt.clientX : evt.touches[0].clientX
         if (clientX < (0.25 * document.documentElement.clientWidth)) {
@@ -240,7 +176,7 @@ export default {
         }
       }
     },
-    wheel: throttle(function (evt) {
+    handleWheel: throttle(function (evt) {
       if (this.mouseNavigation && this.currentSlide.mouseNavigation) {
         evt.preventDefault()
         if ((evt.wheelDeltaY > 0) || (evt.deltaY > 0)) {
@@ -250,7 +186,7 @@ export default {
         }
       }
     }, 1000),
-    keydown: function (evt) {
+    handleKeydown: function (evt) {
       if (this.keyboardNavigation &&
           (this.currentSlide.keyboardNavigation || evt.ctrlKey || evt.metaKey)) {
         if (evt.key === 'ArrowLeft' || evt.key === 'PageUp') {
@@ -259,37 +195,8 @@ export default {
         } else if (evt.key === 'ArrowRight' || evt.key === 'PageDown') {
           this.nextStep()
           evt.preventDefault()
-        } else if (evt.key === this.presenterModeKey && !this.parentWindow) {
-          this.togglePresenterMode()
-          evt.preventDefault()
         }
       }
-    },
-    _message: function (evt) {
-      if (evt.origin !== window.location.origin) {
-        return void 0
-      }
-      try {
-        var data = JSON.parse(evt.data)
-        switch (data.method) {
-          case 'nextStep':
-          case 'previousStep':
-            this[data.method](true)
-            break
-          case 'getCurrentSlide':
-            this.postMessage(`{
-              "method": "setCurrentSlide", 
-              "slideIndex": ${this.currentSlideIndex},
-              "step": ${this.step}
-              }`)
-            break
-          case 'setCurrentSlide':
-            this.currentSlideIndex = data.slideIndex
-            this.$nextTick(() => { this.step = data.step })
-            break
-          default:
-        }
-      } catch (e) {}
     },
     afterMounted: function () {
       // useful in some instances
@@ -329,21 +236,18 @@ export default {
         this.$el.style.visibility = 'hidden'
       }
     },
-    postMessage: function (message) {
-      if (this.childWindow) {
-        this.childWindow.postMessage(message, window.location.origin)
-      }
-      if (this.parentWindow) {
-        this.parentWindow.postMessage(message, window.location.origin)
+    registerPlugins: function () {
+      if (Options.plugins) {
+        Options.plugins.forEach(plugin => {
+          plugin[0].init(this, plugin[1])
+        })
       }
     },
-    togglePresenterMode: function () {
-      if (this.childWindow) {
-        this.childWindow.close()
-        this.childWindow = null
-      } else {
-        this.childWindow = window.open(window.location.href, 'eagle-presenter')
-        window.addEventListener('message', this._message)
+    unregisterPlugins: function () {
+      if (Options.plugins) {
+        Options.plugins.forEach(plugin => {
+          plugin[0].destroy(this)
+        })
       }
     }
   },

--- a/src/components/plugins/presenter.js
+++ b/src/components/plugins/presenter.js
@@ -6,12 +6,23 @@ function keydown (evt) {
   if (slideshow.keyboardNavigation &&
       (slideshow.currentSlide.keyboardNavigation || evt.ctrlKey || evt.metaKey)) {
     if (evt.key === 'ArrowLeft' || evt.key === 'PageUp') {
-      postMessage('{"method": "nextStep"}')
-    } else if (evt.key === 'ArrowRight' || evt.key === 'PageDown') {
       postMessage('{"method": "previousStep"}')
+    } else if (evt.key === 'ArrowRight' || evt.key === 'PageDown') {
+      postMessage('{"method": "nextStep"}')
     } else if (evt.key === presenterModeKey && !this.parentWindow) {
       togglePresenterMode()
       evt.preventDefault()
+    }
+  }
+}
+
+function click (evt) {
+  if (slideshow.mouseNavigation && slideshow.currentSlide.mouseNavigation && !evt.altKey) {
+    const clientX = evt.clientX != null ? evt.clientX : evt.touches[0].clientX
+    if (clientX < (0.25 * document.documentElement.clientWidth)) {
+      postMessage('{"method": "previousStep"}')
+    } else if (clientX > (0.75 * document.documentElement.clientWidth)) {
+      postMessage('{"method": "nextStep"}')
     }
   }
 }
@@ -73,10 +84,12 @@ export default {
         window.addEventListener('message', message)
       }
       window.addEventListener('keydown', keydown)
+      window.addEventListener('click', click)
     }
   },
   destroy: function () {
     window.removeEventListener('message', message)
     window.removeEventListener('keydown', keydown)
+    window.addEventListener('click', click)
   }
 }

--- a/src/components/plugins/presenter.js
+++ b/src/components/plugins/presenter.js
@@ -1,0 +1,82 @@
+let slideshow, childWindow, parentWindow
+// default config
+let presenterModeKey = 'p'
+
+function keydown (evt) {
+  if (slideshow.keyboardNavigation &&
+      (slideshow.currentSlide.keyboardNavigation || evt.ctrlKey || evt.metaKey)) {
+    if (evt.key === 'ArrowLeft' || evt.key === 'PageUp') {
+      postMessage('{"method": "nextStep"}')
+    } else if (evt.key === 'ArrowRight' || evt.key === 'PageDown') {
+      postMessage('{"method": "previousStep"}')
+    } else if (evt.key === presenterModeKey && !this.parentWindow) {
+      togglePresenterMode()
+      evt.preventDefault()
+    }
+  }
+}
+
+function postMessage (message) {
+  if (childWindow) {
+    childWindow.postMessage(message, window.location.origin)
+  }
+  if (parentWindow) {
+    parentWindow.postMessage(message, window.location.origin)
+  }
+}
+
+function togglePresenterMode () {
+  if (childWindow) {
+    childWindow.close()
+    childWindow = null
+  } else {
+    childWindow = window.open(window.location.href, 'eagle-presenter')
+    window.addEventListener('message', message)
+  }
+}
+
+function message (evt) {
+  if (evt.origin !== window.location.origin) {
+    return void 0
+  }
+  try {
+    var data = JSON.parse(evt.data)
+    switch (data.method) {
+      case 'nextStep':
+      case 'previousStep':
+        slideshow[data.method]()
+        break
+      case 'getCurrentSlide':
+        postMessage(`{
+          "method": "setCurrentSlide", 
+          "slideIndex": ${slideshow.currentSlideIndex},
+          "step": ${slideshow.step}
+          }`)
+        break
+      case 'setCurrentSlide':
+        slideshow.currentSlideIndex = data.slideIndex
+        slideshow.$nextTick(() => { slideshow.step = data.step })
+        break
+      default:
+    }
+  } catch (e) {}
+}
+
+export default {
+  isPlugin: true,
+  init: function (s) {
+    slideshow = s
+    if (!slideshow.inserted) {
+      if (window.opener && window.opener.location.href === window.location.href) {
+        parentWindow = window.opener
+        postMessage('{"method": "getCurrentSlide"}')
+        window.addEventListener('message', message)
+      }
+      window.addEventListener('keydown', keydown)
+    }
+  },
+  destroy: function () {
+    window.removeEventListener('message', message)
+    window.removeEventListener('keydown', keydown)
+  }
+}

--- a/src/components/plugins/presenter.js
+++ b/src/components/plugins/presenter.js
@@ -75,7 +75,8 @@ function message (evt) {
 
 export default {
   isPlugin: true,
-  init: function (s) {
+  init: function (s, config) {
+    presenterModeKey = config.presenterModeKey || presenterModeKey
     slideshow = s
     if (!slideshow.inserted) {
       if (window.opener && window.opener.location.href === window.location.href) {

--- a/src/components/plugins/zoom.js
+++ b/src/components/plugins/zoom.js
@@ -1,0 +1,58 @@
+let height, width, center, boundary
+// default config
+let scale = 2
+
+function updateCoords () {
+  height = document.documentElement.clientHeight
+  width = document.documentElement.clientWidth
+  center.x = width / 2
+  center.y = height / 2
+  boundary.x = center.x / scale
+  boundary.y = center.y / scale
+}
+
+function magnify (event) {
+  if (!event.altKey) return
+  if (document.body.style.transform) {
+    document.body.style.transform = ''
+    document.body.style.overflow = 'auto'
+  } else {
+    document.body.style.height = height + 'px'
+    document.body.style.overflow = 'hidden'
+    document.body.style.transition = '0.5s'
+    let translateX = center.x - event.clientX
+    let translateY = center.y - event.clientY
+    translateX = translateX < boundary.x ? translateX > -boundary.x ? translateX : -boundary.x : boundary.x
+    translateY = translateY < boundary.y ? translateY > -boundary.y ? translateY : -boundary.y : boundary.y
+    document.body.style.transform = `scale(${scale}) translate(${translateX}px, ${translateY}px)`
+  }
+}
+
+export default {
+  isPlugin: true,
+  init: function (slideshow, config) {
+    // zoom can be only enabled by main slideshow
+    if (!slideshow.embedded) return
+
+    scale = config.scale
+    height = document.documentElement.clientHeight
+    width = document.documentElement.clientWidth
+    center = {
+      x: width / 2,
+      y: height / 2
+    }
+    boundary = {
+      x: center.x / scale,
+      y: center.y / scale
+    }
+
+    window.addEventListener('resize', updateCoords)
+    window.addEventListener('mousedown', magnify)
+  },
+  destroy: function () {
+    window.removeEventListener('resize', updateCoords)
+    window.removeEventListener('mousedown', magnify)
+  }
+
+}
+

--- a/src/components/plugins/zoom.js
+++ b/src/components/plugins/zoom.js
@@ -34,7 +34,7 @@ export default {
     // zoom can be only enabled by main slideshow
     if (!slideshow.embedded) return
 
-    scale = config.scale
+    scale = config.scale || scale
     height = document.documentElement.clientHeight
     width = document.documentElement.clientWidth
     center = {

--- a/src/components/widgets/CodeBlock.vue
+++ b/src/components/widgets/CodeBlock.vue
@@ -17,6 +17,7 @@ function randId () {
 }
 
 export default {
+  isWidget: true,
   name: 'eg-code-block',
   props: {
     id: {default: () => randId()},

--- a/src/components/widgets/CodeComment.vue
+++ b/src/components/widgets/CodeComment.vue
@@ -6,6 +6,7 @@ eg-transition(:enter='enter', :leave='leave')
 </template>
 <script>
 export default {
+  isWidget: true,
   name: 'eg-code-comment',
   props: {
     enter: {default: null},

--- a/src/components/widgets/ImageSlide.vue
+++ b/src/components/widgets/ImageSlide.vue
@@ -7,6 +7,7 @@ eg-transition(:enter='enter', :leave='leave')
 <script>
 import Slide from '../Slide.vue'
 export default {
+  isWidget: true,
   name: 'eg-image-slide',
   mixins: [Slide],
   props: {

--- a/src/components/widgets/Modal.vue
+++ b/src/components/widgets/Modal.vue
@@ -6,6 +6,7 @@
 
 <script>
 export default {
+  isWidget: true,
   name: 'eg-modal'
 }
 </script>

--- a/src/components/widgets/RadioButton.vue
+++ b/src/components/widgets/RadioButton.vue
@@ -8,6 +8,7 @@
 
 <script>
 export default {
+  isWidget: true,
   name: 'eg-radio-button',
   props: {
     value: {default: null},

--- a/src/components/widgets/Timer.vue
+++ b/src/components/widgets/Timer.vue
@@ -7,6 +7,7 @@ eg-transition(enter='fadeIn' leave='fadeOut')
 
 <script>
 export default {
+  isWidget: true,
   name: 'eg-timer',
   props: {
     key: {default: 'T'}

--- a/src/components/widgets/Toggle.vue
+++ b/src/components/widgets/Toggle.vue
@@ -12,6 +12,7 @@
 
 <script>
 export default {
+  isWidget: true,
   name: 'eg-toggle',
   props: {
     value: {default: true},

--- a/src/components/widgets/TriggeredMessage.vue
+++ b/src/components/widgets/TriggeredMessage.vue
@@ -5,6 +5,7 @@ eg-transition(:enter='enter', :leave='leave')
 </template>
 <script>
 export default {
+  isWidget: true,
   name: 'eg-triggered-message',
   props: {
     enter: {default: 'slideInLeft'},

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,25 @@
+import Vue from 'vue'
+
 import Slideshow from './components/Slideshow.vue'
 import Slide from './components/Slide.vue'
+import Transition from './components/AnimatedTransition.vue'
+
 import Modal from './components/widgets/Modal.vue'
 import CodeBlock from './components/widgets/CodeBlock.vue'
 import CodeComment from './components/widgets/CodeComment.vue'
 import Toggle from './components/widgets/Toggle.vue'
-import Transition from './components/AnimatedTransition.vue'
 import RadioButton from './components/widgets/RadioButton.vue'
 import ImageSlide from './components//widgets/ImageSlide.vue'
 import TriggeredMessage from './components/widgets/TriggeredMessage.vue'
 import Timer from './components/widgets/Timer.vue'
 
-const Options = {}
+import Zoom from './components/plugins/zoom'
+import Presenter from './components/plugins/presenter'
+
+const Options = {
+  plugins: []
+  // hljs: used by CodeBlock widget
+}
 
 export {
   Slideshow,
@@ -24,22 +33,24 @@ export {
   ImageSlide,
   TriggeredMessage,
   Timer,
+
+  Zoom,
+  Presenter,
+
   Options
 }
 
 export default {
-  slideshow: Slideshow,
-  slide: Slide,
   install (Vue) {
     Vue.component('slide', Slide)
-    Vue.component('eg-image-slide', ImageSlide)
-    Vue.component('eg-modal', Modal)
     Vue.component('eg-transition', Transition)
-    Vue.component('eg-code-block', CodeBlock)
-    Vue.component('eg-code-comment', CodeComment)
-    Vue.component('eg-toggle', Toggle)
-    Vue.component('eg-radio-button', RadioButton)
-    Vue.component('eg-timer', Timer)
-    Vue.component('eg-triggered-message', TriggeredMessage)
+  },
+  use (extension, config) {
+    if (extension.isPlugin) {
+      Options.plugins.push([extension, config])
+    }
+    if (extension.isWidget) {
+      Vue.component(extension.name, extension)
+    }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -33,10 +33,8 @@ export {
   ImageSlide,
   TriggeredMessage,
   Timer,
-
   Zoom,
   Presenter,
-
   Options
 }
 

--- a/stories/stories.js
+++ b/stories/stories.js
@@ -1,12 +1,14 @@
 import Vue from 'vue'
 import { storiesOf } from '@storybook/vue'
-import Eagle, { Slideshow } from '../src/main.js'
+import Eagle, { Slideshow, Zoom, Presenter } from '../src/main.js'
 
 import '../src/themes/agrume/agrume.scss' 
 import '../src/themes/gourmet/gourmet.scss' 
 import 'animate.css'
 
 Vue.use(Eagle)
+Eagle.use(Zoom)
+Eagle.use(Presenter)
 
 const render = (slides, useTheme=true, theme='agrume') => {
   const template = (useTheme ? `<div class='eg-theme-${theme}'>` : '') +

--- a/test/unit/Slideshow.spec.js
+++ b/test/unit/Slideshow.spec.js
@@ -30,7 +30,6 @@ describe('Slideshow properties', () => {
     expect(wrapper.props().skip).toBe(false)
     expect(wrapper.props().backBySlide).toBe(false)
     expect(wrapper.props().repeat).toBe(false)
-    expect(wrapper.props().zoom).toBe(true)
   })
 
   it('user set props matches', () => {
@@ -47,7 +46,6 @@ describe('Slideshow properties', () => {
         skip: true,
         backBySlide: true,
         repeat: true,
-        zoom: false
       }
     })
     expect(wrapper.props().firstSlide).toBe(2)
@@ -60,7 +58,6 @@ describe('Slideshow properties', () => {
     expect(wrapper.props().skip).toBe(true)
     expect(wrapper.props().backBySlide).toBe(true)
     expect(wrapper.props().repeat).toBe(true)
-    expect(wrapper.props().zoom).toBe(false)
   })
 
   it('props work in slideshow initialization', () => {
@@ -115,7 +112,7 @@ describe('Slideshow lifecycle hooks', () => {
     expect(window.addEventListener.mock.calls[3][0]).toEqual('resize')
   })
 
-  it('should register additional events for zoom', () => {
+  xit('should register additional events for zoom', () => {
     jest.spyOn(window, 'addEventListener')
     wrapper = mount(Slideshow, {
       attachToDocument: true,


### PR DESCRIPTION
The PR aims to help solve the issue of unnecessary to core yet useful addition to Eagle.js ecosystem.

Here I propose a new concept: extensitions. It includes two categories, namely widgets and plugins.

1. Widgets are the Vue component that can be used in a slide.
2. Plugins are used mostly in slideshow to enhance slide.

Both widgets and plugins have the same interface to use, just like how Vue uses plugins, for example

```
// plugin
Eagle.use(Zoom, {scale: 2})
// Widget
Eagle.use(CodeBlock)
```

To do this I have extract the two main plugins (presenter mode and zoom) into their own files.

## Plugin

Plugins are used mostly by "config", like how we "use" Eagle.js. A plugin has three common properties: `init`, `destroy` and `isPlugin`. For each plugin, `init` is called after slideshow is mounted, and `destroy` is called before slideshow destroys.

## Widget

We can still use widget like the old way:

```
Vue.component(widget.name, widget)
```  

The new `Eagle.use` is just a wrapper of the above call.

I really appreciate if @Zulko can take a look! 

