### PR TITLE
fix(findSlides): option to reset index

### DIFF
--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -294,7 +294,7 @@ export default {
     afterMounted: function () {
       // useful in some instances
     },
-    findSlides: function ({resetIndex = true}) {
+    findSlides: function ({resetIndex = true} = {}) {
       var self = this
       var i = 0
       self.slides = []

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -294,7 +294,7 @@ export default {
     afterMounted: function () {
       // useful in some instances
     },
-    findSlides: function () {
+    findSlides: function ({resetIndex = true}) {
       var self = this
       var i = 0
       self.slides = []
@@ -316,9 +316,11 @@ export default {
           })
         }
       })
-      self.currentSlideIndex = 1
-      self.currentSlide = self.currentSlide === null ? null : self.slides[0]
-      self.step = self.startStep
+      if (resetIndex) {
+        self.currentSlideIndex = 1
+        self.currentSlide = self.currentSlide === null ? null : self.slides[0]
+        self.step = self.startStep
+      }
     },
     updateSlideshowVisibility: function (val) {
       if (val) {


### PR DESCRIPTION
Hello folks,

I'm using eagle.js to do a slideshow and I contact an API with a setInterval to add slides progressively so I don't need to reset index of the slideshow
Here is a little option of the modified function `findSlides` to not reset the index 

I use JS destructuring instead of simple parameter to let options the possibility to grow without carrying about index of parameter.
Also a better option (but breaking change) would be to not set a default value to the resetIndex but I don't take the shot 😆 

Happy holidays !