### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ You can configure your authored `slideshow` component with these properties:
 
 | Property             | Default         | Description                                               |
 | -------------------- | --------------- | --------------------------------------------------------- |
-| `firstslide`         | `1`             |                                                           |
-| `lastslide`          | `null`          |                                                           |
+| `firstSlide`         | `1`             |                                                           |
+| `lastSlide`          | `null`          |                                                           |
 | `startStep`          | `1`             |                                                           | 
 | `mouseNavigation`    | `true`          | Navigate with mouse click or scroll event                 |
 | `keyboardNavigation` | `true`          | Navigate with keyboard                                    |

--- a/src/components/Slideshow.vue
+++ b/src/components/Slideshow.vue
@@ -53,7 +53,7 @@ export default {
       }
       if (this.mouseNavigation) {
         if ('ontouchstart' in window) {
-          window.addEventListener('touchstart', this.hanldeClick)
+          window.addEventListener('touchstart', this.handleClick)
         } else {
           window.addEventListener('click', this.handleClick)
           window.addEventListener('wheel', this.handleWheel)


### PR DESCRIPTION
1. Property Names are camelCase, not lowercase - corrected in README.md to prevent confusion. 
2. Function name is ```handleClick``` not ```hanldeClick```.